### PR TITLE
Fix plain lyrics when publishing to LRCLIB

### DIFF
--- a/chronograph/utils/publish.py
+++ b/chronograph/utils/publish.py
@@ -63,7 +63,7 @@ def make_plain_lyrics(lyrics: str) -> str:
     pattern = r"\[.*?\] "
     lyrics = lyrics.splitlines()
     plain_lyrics = []
-    for line in plain_lyrics:
+    for line in lyrics:
         plain_lyrics.append(re.sub(pattern, "", line))
     return "\n".join(plain_lyrics[:-1])
 


### PR DESCRIPTION
Previously, the plain lyrics were identical to the synced lyrics (except for the first line). With this patch, they should be published correctly.